### PR TITLE
Turn off MIPSDK compile time warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ find_package(catkin REQUIRED COMPONENTS
   nav_msgs
 )
 
+set(CMAKE_C_FLAGS "-Wno-implicit-function-declaration -Wno-incompatible-pointer-types -Wno-format -fno-builtin-memcpy")
+
 ###################################
 ## catkin specific configuration ##
 ###################################


### PR DESCRIPTION
The included MIPSDK throws warnings on build. As it's a copied/as delivered SDK, turn off the corresponding warnings instead of fixing them.