### PR TITLE
Added static IMU message covariance population via parameters.

### DIFF
--- a/include/microstrain_mips/microstrain_3dm.h
+++ b/include/microstrain_mips/microstrain_3dm.h
@@ -309,6 +309,9 @@ namespace Microstrain
   bool publish_imu_;
   bool publish_odom_;
   bool publish_bias_;
+  std::vector<double> imu_linear_cov_;
+  std::vector<double> imu_angular_cov_;
+  std::vector<double> imu_orientation_cov_;
 
   //Device Flags
   bool GX5_15;

--- a/launch/microstrain.launch
+++ b/launch/microstrain.launch
@@ -37,6 +37,11 @@
     <!-- Declination source 1=None, 2=magnetic, 3=manual -->
     <param name="declination_source" value="2" type="int" />
     <param name="declination" value="0.23" type="double" />
+    <!-- Static IMU message covariance values -->
+    <!-- Since internally these are std::vector we need to use the rosparam tags -->
+    <rosparam param="imu_orientation_cov"> [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]</rosparam>
+    <rosparam param="imu_linear_cov"> [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]</rosparam>
+    <rosparam param="imu_angular_cov"> [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]</rosparam>
 
     <!-- GPS Settings  -45 and -35 Only -->
     <param name="gps_rate" value="4" type="int" />

--- a/src/microstrain_3dm.cpp
+++ b/src/microstrain_3dm.cpp
@@ -157,13 +157,6 @@ namespace Microstrain
     private_nh.param("imu_linear_cov",imu_linear_cov_, default_cov);
     private_nh.param("imu_angular_cov",imu_angular_cov_, default_cov);
 
-
-    ROS_INFO("Publishing the values: %d, %d",default_cov.size(),imu_orientation_cov_.size());
-    for( unsigned int a = 0; a < imu_orientation_cov_.size(); a = a + 1 )
-    {
-      ROS_INFO("Imu orientation values: %f",imu_orientation_cov_[a]);
-    }
-
     // ROS publishers and subscribers
     if (publish_imu_)
       imu_pub_ = node.advertise<sensor_msgs::Imu>("imu/data",100);


### PR DESCRIPTION
See issue #19 

This allows for static population via parameters of the imu covariance values. Will work on new PR based on last few issues that were encountered since there are no uncertainty values in the AHRS data packet.