### PR TITLE
Enu/ned/swap

### DIFF
--- a/include/microstrain_mips/microstrain_3dm.h
+++ b/include/microstrain_mips/microstrain_3dm.h
@@ -47,6 +47,7 @@ extern "C"
 #include "sensor_msgs/NavSatFix.h"
 #include "sensor_msgs/Imu.h"
 #include "geometry_msgs/PoseWithCovarianceStamped.h"
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 #include "geometry_msgs/Vector3.h"
 #include "nav_msgs/Odometry.h"
 #include "std_msgs/Int8.h"

--- a/include/microstrain_mips/microstrain_3dm.h
+++ b/include/microstrain_mips/microstrain_3dm.h
@@ -310,6 +310,7 @@ namespace Microstrain
     bool publish_bias_;
     bool publish_filtered_imu_;
     bool remove_imu_gravity_;
+    bool frame_based_enu_;
     std::vector<double> imu_linear_cov_;
     std::vector<double> imu_angular_cov_;
     std::vector<double> imu_orientation_cov_;

--- a/include/microstrain_mips/microstrain_3dm.h
+++ b/include/microstrain_mips/microstrain_3dm.h
@@ -42,7 +42,6 @@ extern "C"
 #include <unistd.h>
 #include <time.h>
 
-
 // ROS
 #include "ros/ros.h"
 #include "sensor_msgs/NavSatFix.h"
@@ -82,7 +81,6 @@ extern "C"
 #include "microstrain_mips/SetMagAdaptiveVals.h"
 #include "microstrain_mips/SetMagDipAdaptiveVals.h"
 
-
 #define MIP_SDK_GX4_45_IMU_STANDARD_MODE  0x01
 #define MIP_SDK_GX4_45_IMU_DIRECT_MODE  0x02
 
@@ -97,8 +95,6 @@ extern "C"
 #define GX5_35_DEVICE "3DM-GX5-35"
 #define GX5_25_DEVICE "3DM-GX5-25"
 #define GX5_15_DEVICE "3DM-GX5-15"
-
-
 
 /**
  * \brief Contains functions for micostrain driver
@@ -240,134 +236,134 @@ namespace Microstrain
 
 
   private:
-  //! @brief Reset KF service callback
-  bool reset_callback(std_srvs::Empty::Request &req,
-          std_srvs::Empty::Response &resp);
-  //! @brief Convience for printing packet stats
-  void print_packet_stats();
+    //! @brief Reset KF service callback
+    bool reset_callback(std_srvs::Empty::Request &req,
+            std_srvs::Empty::Response &resp);
+    //! @brief Convience for printing packet stats
+    void print_packet_stats();
 
+    // Variables/fields
+    //The primary device interface structure
+    mip_interface device_interface_;
+    base_device_info_field device_info;
+    u8  temp_string[20];
 
+    //Packet Counters (valid, timeout, and checksum errors)
+    u32 filter_valid_packet_count_;
+    u32 ahrs_valid_packet_count_;
+    u32 gps_valid_packet_count_;
 
-  // Variables/fields
-  //The primary device interface structure
-  mip_interface device_interface_;
-  base_device_info_field device_info;
-  u8  temp_string[20];
+    u32 filter_timeout_packet_count_;
+    u32 ahrs_timeout_packet_count_;
+    u32 gps_timeout_packet_count_;
 
-  //Packet Counters (valid, timeout, and checksum errors)
-  u32 filter_valid_packet_count_;
-  u32 ahrs_valid_packet_count_;
-  u32 gps_valid_packet_count_;
+    u32 filter_checksum_error_packet_count_;
+    u32 ahrs_checksum_error_packet_count_;
+    u32 gps_checksum_error_packet_count_;
 
-  u32 filter_timeout_packet_count_;
-  u32 ahrs_timeout_packet_count_;
-  u32 gps_timeout_packet_count_;
+    //Data field storage
+    //AHRS
+    mip_ahrs_scaled_gyro  curr_ahrs_gyro_;
+    mip_ahrs_scaled_accel curr_ahrs_accel_;
+    mip_ahrs_scaled_mag   curr_ahrs_mag_;
+    mip_ahrs_quaternion  curr_ahrs_quaternion_;
+    //GPS
+    mip_gps_llh_pos curr_llh_pos_;
+    mip_gps_ned_vel curr_ned_vel_;
+    mip_gps_time    curr_gps_time_;
 
-  u32 filter_checksum_error_packet_count_;
-  u32 ahrs_checksum_error_packet_count_;
-  u32 gps_checksum_error_packet_count_;
+    //FILTER
+    mip_filter_llh_pos               curr_filter_pos_;
+    mip_filter_ned_velocity          curr_filter_vel_;
+    mip_filter_attitude_euler_angles curr_filter_angles_;
+    mip_filter_attitude_quaternion   curr_filter_quaternion_;
+    mip_filter_compensated_angular_rate curr_filter_angular_rate_;
+    mip_filter_compensated_acceleration curr_filter_accel_comp_;
+    mip_filter_linear_acceleration curr_filter_linear_accel_;
+    mip_filter_llh_pos_uncertainty   curr_filter_pos_uncertainty_;
+    mip_filter_ned_vel_uncertainty   curr_filter_vel_uncertainty_;
+    mip_filter_euler_attitude_uncertainty curr_filter_att_uncertainty_;
+    mip_filter_status curr_filter_status_;
 
-  //Data field storage
-  //AHRS
-  mip_ahrs_scaled_gyro  curr_ahrs_gyro_;
-  mip_ahrs_scaled_accel curr_ahrs_accel_;
-  mip_ahrs_scaled_mag   curr_ahrs_mag_;
-  mip_ahrs_quaternion  curr_ahrs_quaternion_;
-  //GPS
-  mip_gps_llh_pos curr_llh_pos_;
-  mip_gps_ned_vel curr_ned_vel_;
-  mip_gps_time    curr_gps_time_;
+    // ROS
+    ros::Publisher gps_pub_;
+    ros::Publisher imu_pub_;
+    ros::Publisher filtered_imu_pub_;
+    ros::Publisher nav_pub_;
+    ros::Publisher nav_status_pub_;
+    ros::Publisher bias_pub_;
+    ros::Publisher device_status_pub_;
+    sensor_msgs::NavSatFix gps_msg_;
+    sensor_msgs::Imu imu_msg_;
+    sensor_msgs::Imu filtered_imu_msg_;
+    nav_msgs::Odometry nav_msg_;
+    std_msgs::Int16MultiArray nav_status_msg_;
+    geometry_msgs::Vector3 bias_msg_;
+    std::string gps_frame_id_;
+    std::string imu_frame_id_;
+    std::string odom_frame_id_;
+    std::string odom_child_frame_id_;
+    microstrain_mips::status_msg device_status_msg_;
+    bool publish_gps_;
+    bool publish_imu_;
+    bool publish_odom_;
+    bool publish_bias_;
+    bool publish_filtered_imu_;
+    bool remove_imu_gravity_;
+    std::vector<double> imu_linear_cov_;
+    std::vector<double> imu_angular_cov_;
+    std::vector<double> imu_orientation_cov_;
 
-  //FILTER
-  mip_filter_llh_pos               curr_filter_pos_;
-  mip_filter_ned_velocity          curr_filter_vel_;
-  mip_filter_attitude_euler_angles curr_filter_angles_;
-  mip_filter_attitude_quaternion   curr_filter_quaternion_;
-  mip_filter_compensated_angular_rate curr_filter_angular_rate_;
-  mip_filter_llh_pos_uncertainty   curr_filter_pos_uncertainty_;
-  mip_filter_ned_vel_uncertainty   curr_filter_vel_uncertainty_;
-  mip_filter_euler_attitude_uncertainty curr_filter_att_uncertainty_;
-  mip_filter_status curr_filter_status_;
+    //Device Flags
+    bool GX5_15;
+    bool GX5_25;
+    bool GX5_35;
+    bool GX5_45;
+    bool GQX_45;
+    bool RQX_45;
+    bool CXX_45;
+    bool CVX_10;
+    bool CVX_15;
+    bool CVX_25;
 
-  // ROS
-  ros::Publisher gps_pub_;
-  ros::Publisher imu_pub_;
-  ros::Publisher nav_pub_;
-  ros::Publisher nav_status_pub_;
-  ros::Publisher bias_pub_;
-  ros::Publisher device_status_pub_;
-  sensor_msgs::NavSatFix gps_msg_;
-  sensor_msgs::Imu imu_msg_;
-  nav_msgs::Odometry nav_msg_;
-  std_msgs::Int16MultiArray nav_status_msg_;
-  geometry_msgs::Vector3 bias_msg_;
-  std::string gps_frame_id_;
-  std::string imu_frame_id_;
-  std::string odom_frame_id_;
-  std::string odom_child_frame_id_;
-  microstrain_mips::status_msg device_status_msg_;
-  bool publish_gps_;
-  bool publish_imu_;
-  bool publish_odom_;
-  bool publish_bias_;
-  std::vector<double> imu_linear_cov_;
-  std::vector<double> imu_angular_cov_;
-  std::vector<double> imu_orientation_cov_;
+    // Update rates
+    int nav_rate_;
+    int imu_rate_;
+    int gps_rate_;
 
-  //Device Flags
-  bool GX5_15;
-  bool GX5_25;
-  bool GX5_35;
-  bool GX5_45;
-  bool GQX_45;
-  bool RQX_45;
-  bool CXX_45;
-  bool CVX_10;
-  bool CVX_15;
-  bool CVX_25;
-
-
-
-
-
-  // Update rates
-  int nav_rate_;
-  int imu_rate_;
-  int gps_rate_;
-
-  clock_t start;
-  float field_data[3];
-  float soft_iron[9];
-  float soft_iron_readback[9];
-  float angles[3];
-  float heading_angle;
-  float readback_angles[3];
-  float noise[3];
-  float beta[3];
-  float readback_beta[3];
-  float readback_noise[3];
-  float offset[3];
-  float readback_offset[3];
-  u8  com_mode;
-  u16 duration;
-  u8 reference_position_enable_command;
-  u8 reference_position_enable_readback;
-  double reference_position_command[3];
-  double reference_position_readback[3];
-  u8 enable_flag;
-  u16 estimation_control;
-  u16 estimation_control_readback;
-  u8 dynamics_mode;
-  u8 readback_dynamics_mode;
-  gx4_25_basic_status_field basic_field;
-  gx4_25_diagnostic_device_status_field diagnostic_field;
-  gx4_45_basic_status_field basic_field_45;
-  gx4_45_diagnostic_device_status_field diagnostic_field_45;
-  mip_complementary_filter_settings comp_filter_command, comp_filter_readback;
-  mip_filter_accel_magnitude_error_adaptive_measurement_command accel_magnitude_error_command, accel_magnitude_error_readback;
-  mip_filter_magnetometer_magnitude_error_adaptive_measurement_command mag_magnitude_error_command, mag_magnitude_error_readback;
-  mip_filter_magnetometer_dip_angle_error_adaptive_measurement_command mag_dip_angle_error_command, mag_dip_angle_error_readback;
-  mip_filter_zero_update_command zero_update_control, zero_update_readback;
+    clock_t start;
+    float field_data[3];
+    float soft_iron[9];
+    float soft_iron_readback[9];
+    float angles[3];
+    float heading_angle;
+    float readback_angles[3];
+    float noise[3];
+    float beta[3];
+    float readback_beta[3];
+    float readback_noise[3];
+    float offset[3];
+    float readback_offset[3];
+    u8  com_mode;
+    u16 duration;
+    u8 reference_position_enable_command;
+    u8 reference_position_enable_readback;
+    double reference_position_command[3];
+    double reference_position_readback[3];
+    u8 enable_flag;
+    u16 estimation_control;
+    u16 estimation_control_readback;
+    u8 dynamics_mode;
+    u8 readback_dynamics_mode;
+    gx4_25_basic_status_field basic_field;
+    gx4_25_diagnostic_device_status_field diagnostic_field;
+    gx4_45_basic_status_field basic_field_45;
+    gx4_45_diagnostic_device_status_field diagnostic_field_45;
+    mip_complementary_filter_settings comp_filter_command, comp_filter_readback;
+    mip_filter_accel_magnitude_error_adaptive_measurement_command accel_magnitude_error_command, accel_magnitude_error_readback;
+    mip_filter_magnetometer_magnitude_error_adaptive_measurement_command mag_magnitude_error_command, mag_magnitude_error_readback;
+    mip_filter_magnetometer_dip_angle_error_adaptive_measurement_command mag_dip_angle_error_command, mag_dip_angle_error_readback;
+    mip_filter_zero_update_command zero_update_control, zero_update_readback;
   }; // Microstrain class
 
 

--- a/launch/microstrain.launch
+++ b/launch/microstrain.launch
@@ -40,7 +40,7 @@
     <!-- Filtered IMU rate is based on nav_rate since it is tied in with the onboard Kalman Filter -->
     <!-- If you set the filtered_imu rate to be something fairly high, make sure to lower the IMU rate
           above since it appears that the data rate can flood the USB. -->
-    <param name="publish_filtered_imu" value="true" type="bool" />
+    <param name="publish_filtered_imu" value="false" type="bool" />
     <!-- Remove gravity is only valid with the filtered IMU data. -->
     <param name="remove_imu_gravity" value="true" type="bool" />
     <!-- Static IMU message covariance values -->

--- a/launch/microstrain.launch
+++ b/launch/microstrain.launch
@@ -29,6 +29,12 @@
     <param name="save_settings" value="true" type="bool" />
     <param name="auto_init" value="true" type="bool" />
 
+    <!-- This parameter is to set wether the device orientation uses a basic 
+      NED->ENU orientation swap or not. If true, the ENU reported should
+      match the label printed on the device. If false X & Y are swapped
+      and Z is negated. -->
+    <param name="frame_based_enu" value="false" type="bool" />
+
     <!-- The GX5-25 is AHRS only, so need to turn off the other messages -->
     <!-- AHRS Settings -->
     <param name="publish_imu" value="true" type="bool" />

--- a/launch/microstrain.launch
+++ b/launch/microstrain.launch
@@ -3,7 +3,7 @@
   <!-- Standalone example launch file for 3DM-GX5-25 -->
 
   <!-- Declare arguments with default values -->
-  <arg name="port" default="/dev/microstrain" />
+  <arg name="port" default="/dev/ttyACM0" />
   <arg name="baudrate" default="115200" />
   <arg name="imu_rate" default="100" />
   <arg name="imu_frame_id" default="gx5_link" />
@@ -37,6 +37,12 @@
     <!-- Declination source 1=None, 2=magnetic, 3=manual -->
     <param name="declination_source" value="2" type="int" />
     <param name="declination" value="0.23" type="double" />
+    <!-- Filtered IMU rate is based on nav_rate since it is tied in with the onboard Kalman Filter -->
+    <!-- If you set the filtered_imu rate to be something fairly high, make sure to lower the IMU rate
+          above since it appears that the data rate can flood the USB. -->
+    <param name="publish_filtered_imu" value="true" type="bool" />
+    <!-- Remove gravity is only valid with the filtered IMU data. -->
+    <param name="remove_imu_gravity" value="true" type="bool" />
     <!-- Static IMU message covariance values -->
     <!-- Since internally these are std::vector we need to use the rosparam tags -->
     <rosparam param="imu_orientation_cov"> [0.01, 0, 0, 0, 0.01, 0, 0, 0, 0.01]</rosparam>

--- a/src/microstrain_3dm.cpp
+++ b/src/microstrain_3dm.cpp
@@ -425,7 +425,7 @@ namespace Microstrain
 
       // AHRS Setup
       // Get base rate
-      if (publish_imu_)
+      if (publish_imu_ || publish_filtered_imu_)
       {
         start = clock();
         while (mip_3dm_cmd_get_ahrs_base_rate(&device_interface_, &base_rate) != MIP_INTERFACE_OK)
@@ -439,8 +439,9 @@ namespace Microstrain
 
         ROS_INFO("AHRS Base Rate => %d Hz", base_rate);
         ros::Duration(dT).sleep();
-        // Deterimine decimation to get close to goal rate
-        u8 imu_decimation = (u8)(static_cast<float>(base_rate)/ static_cast<float>(imu_rate_));
+        // Deterimine decimation to get close to goal rate (We use the highest of the imu rates)
+        int rate = (imu_rate_ > nav_rate_) ? imu_rate_ : nav_rate_;
+        u8 imu_decimation = (u8)(static_cast<float>(base_rate)/ static_cast<float>(rate));
         ROS_INFO("AHRS decimation set to %#04X", imu_decimation);
 
         // AHRS Message Format

--- a/src/microstrain_3dm.cpp
+++ b/src/microstrain_3dm.cpp
@@ -3327,14 +3327,14 @@ namespace Microstrain
               mip_filter_attitude_quaternion_byteswap(&curr_filter_quaternion_);
 
               // If we want the orientation to be based on the reference on the imu
-              tf2::Qauternion q(curr_filter_quaternion_.q[1],curr_filter_quaternion_.q[2],
+              tf2::Quaternion q(curr_filter_quaternion_.q[1],curr_filter_quaternion_.q[2],
                                 curr_filter_quaternion_.q[3],curr_filter_quaternion_.q[0]);
               geometry_msgs::Quaternion quat_msg;
 
               if(frame_based_enu_)
               {
                 // Create a rotation from NED -> ENU
-                tf2::Qauternion q_rotate;
+                tf2::Quaternion q_rotate;
                 q_rotate.setRPY(M_PI,0.0,M_PI/2);
                 // Apply the NED to ENU rotation such that the coordinate frame matches
                 q = q_rotate*q;
@@ -3702,14 +3702,14 @@ namespace Microstrain
               mip_ahrs_quaternion_byteswap(&curr_ahrs_quaternion_);
 
               // If we want the orientation to be based on the reference on the imu
-              tf2::Qauternion q(curr_ahrs_quaternion_.q[1],curr_ahrs_quaternion_.q[2],
+              tf2::Quaternion q(curr_ahrs_quaternion_.q[1],curr_ahrs_quaternion_.q[2],
                                 curr_ahrs_quaternion_.q[3],curr_ahrs_quaternion_.q[0]);
               geometry_msgs::Quaternion quat_msg;
 
               if(frame_based_enu_)
               {
                 // Create a rotation from NED -> ENU
-                tf2::Qauternion q_rotate;
+                tf2::Quaternion q_rotate;
                 q_rotate.setRPY(M_PI,0.0,M_PI/2);
                 // Apply the NED to ENU rotation such that the coordinate frame matches
                 q = q_rotate*q;

--- a/src/microstrain_3dm.cpp
+++ b/src/microstrain_3dm.cpp
@@ -152,8 +152,8 @@ namespace Microstrain
 
     private_nh.param("publish_imu", publish_imu_, true);
     private_nh.param("publish_bias", publish_bias_, true);
-    private_nh.param("publish_filtered_imu",publish_filtered_imu_, false);
-    private_nh.param("remove_imu_gravity",remove_imu_gravity_, false);
+    private_nh.param("publish_filtered_imu", publish_filtered_imu_, false);
+    private_nh.param("remove_imu_gravity", remove_imu_gravity_, false);
 
     // Covariance parameters to set the sensor_msg/IMU covariance values
     std::vector<double> default_cov(9, 0.0);
@@ -165,7 +165,7 @@ namespace Microstrain
     if (publish_imu_)
       imu_pub_ = node.advertise<sensor_msgs::Imu>("imu/data", 100);
     if (publish_filtered_imu_)
-      filtered_imu_pub_ = node.advertise<sensor_msgs::Imu>("filtered/imu/data",100);
+      filtered_imu_pub_ = node.advertise<sensor_msgs::Imu>("filtered/imu/data", 100);
 
     // Publishes device status
     device_status_pub_ = node.advertise<microstrain_mips::status_msg>("device/status", 100);
@@ -384,8 +384,8 @@ namespace Microstrain
 
       // This is the EKF filter status, not just navigation/odom status
       if (publish_odom_ || publish_filtered_imu_)
-      {  
-        nav_status_pub_ = node.advertise<std_msgs::Int16MultiArray>("nav/status",100);
+      {
+        nav_status_pub_ = node.advertise<std_msgs::Int16MultiArray>("nav/status", 100);
       }
 
       // Setup device callbacks
@@ -642,10 +642,10 @@ namespace Microstrain
         data_stream_format_descriptors[1] = MIP_FILTER_DATA_ATT_UNCERTAINTY_EULER;
         data_stream_format_descriptors[2] = MIP_FILTER_DATA_COMPENSATED_ANGULAR_RATE;
         data_stream_format_descriptors[3] = MIP_FILTER_DATA_FILTER_STATUS;
-        data_stream_format_decimation[0]  = nav_decimation; //0x32;
-        data_stream_format_decimation[1]  = nav_decimation; //0x32;
-        data_stream_format_decimation[2]  = nav_decimation; //0x32;
-        data_stream_format_decimation[3]  = nav_decimation; //0x32;
+        data_stream_format_decimation[0]  = nav_decimation;  // 0x32;
+        data_stream_format_decimation[1]  = nav_decimation;  // 0x32;
+        data_stream_format_decimation[2]  = nav_decimation;  // 0x32;
+        data_stream_format_decimation[3]  = nav_decimation;  // 0x32;
 
         // If we want the odometry add that data
         if (publish_odom_ && publish_filtered_imu_)
@@ -653,7 +653,7 @@ namespace Microstrain
           // Size is up to 10 elements
           data_stream_format_descriptors[4] = MIP_FILTER_DATA_LLH_POS;
           data_stream_format_descriptors[5] = MIP_FILTER_DATA_NED_VEL;
-          //data_stream_format_descriptors[2] = MIP_FILTER_DATA_ATT_EULER_ANGLES;
+          // data_stream_format_descriptors[2] = MIP_FILTER_DATA_ATT_EULER_ANGLES;
           data_stream_format_descriptors[6] = MIP_FILTER_DATA_POS_UNCERTAINTY;
           data_stream_format_descriptors[7] = MIP_FILTER_DATA_VEL_UNCERTAINTY;
 
@@ -667,30 +667,29 @@ namespace Microstrain
             data_stream_format_descriptors[8] = MIP_FILTER_DATA_COMPENSATED_ACCELERATION;
           }
 
-          data_stream_format_decimation[4]  = nav_decimation; //0x32;
-          data_stream_format_decimation[5]  = nav_decimation; //0x32;
-          data_stream_format_decimation[6]  = nav_decimation; //0x32;
-          data_stream_format_decimation[7]  = nav_decimation; //0x32;
-          data_stream_format_decimation[8]  = nav_decimation; //0x32;
+          data_stream_format_decimation[4]  = nav_decimation;  // 0x32;
+          data_stream_format_decimation[5]  = nav_decimation;  // 0x32;
+          data_stream_format_decimation[6]  = nav_decimation;  // 0x32;
+          data_stream_format_decimation[7]  = nav_decimation;  // 0x32;
+          data_stream_format_decimation[8]  = nav_decimation;  // 0x32;
           data_stream_format_num_entries = 9;
         }
         else if (publish_odom_ && !publish_filtered_imu_)
-        {          
+        {
           data_stream_format_descriptors[4] = MIP_FILTER_DATA_LLH_POS;
           data_stream_format_descriptors[5] = MIP_FILTER_DATA_NED_VEL;
-          //data_stream_format_descriptors[2] = MIP_FILTER_DATA_ATT_EULER_ANGLES;
+          // data_stream_format_descriptors[2] = MIP_FILTER_DATA_ATT_EULER_ANGLES;
           data_stream_format_descriptors[6] = MIP_FILTER_DATA_POS_UNCERTAINTY;
           data_stream_format_descriptors[7] = MIP_FILTER_DATA_VEL_UNCERTAINTY;
 
-          data_stream_format_decimation[4]  = nav_decimation; //0x32;
-          data_stream_format_decimation[5]  = nav_decimation; //0x32;
-          data_stream_format_decimation[6]  = nav_decimation; //0x32;
-          data_stream_format_decimation[7]  = nav_decimation; //0x32;
+          data_stream_format_decimation[4]  = nav_decimation;  // 0x32;
+          data_stream_format_decimation[5]  = nav_decimation;  // 0x32;
+          data_stream_format_decimation[6]  = nav_decimation;  // 0x32;
+          data_stream_format_decimation[7]  = nav_decimation;  // 0x32;
           data_stream_format_num_entries = 8;
         }
         else
         {
-
           // The filter has one message that removes gravity and one that does not
           if (remove_imu_gravity_)
           {
@@ -700,7 +699,7 @@ namespace Microstrain
           {
             data_stream_format_descriptors[4] = MIP_FILTER_DATA_COMPENSATED_ACCELERATION;
           }
-          data_stream_format_decimation[4]  = nav_decimation; //0x32;
+          data_stream_format_decimation[4]  = nav_decimation;  // 0x32;
           data_stream_format_num_entries = 5;
         }
 
@@ -751,7 +750,7 @@ namespace Microstrain
 
 
         // GX5_25 doesn't appear to suport this feature thus GX5_15 probably won't either
-        if(GX5_35 == true || GX5_45 == true)
+        if (GX5_35 == true || GX5_45 == true)
         {
           // Dynamics Mode
           // Set dynamics mode
@@ -3316,7 +3315,7 @@ namespace Microstrain
               nav_msg_.pose.pose.orientation.y = curr_filter_quaternion_.q[1];
               nav_msg_.pose.pose.orientation.z = -1.0*curr_filter_quaternion_.q[3];
               nav_msg_.pose.pose.orientation.w = curr_filter_quaternion_.q[0];
-              
+
               if (publish_filtered_imu_)
               {
                 // Header
@@ -3342,7 +3341,7 @@ namespace Microstrain
               nav_msg_.twist.twist.angular.x = curr_filter_angular_rate_.x;
               nav_msg_.twist.twist.angular.y = curr_filter_angular_rate_.y;
               nav_msg_.twist.twist.angular.z = curr_filter_angular_rate_.z;
-                          
+
               if (publish_filtered_imu_)
               {
                 filtered_imu_msg_.angular_velocity.x = curr_filter_angular_rate_.x;
@@ -3391,12 +3390,15 @@ namespace Microstrain
               nav_msg_.pose.covariance[21] = curr_filter_att_uncertainty_.roll*curr_filter_att_uncertainty_.roll;
               nav_msg_.pose.covariance[28] = curr_filter_att_uncertainty_.pitch*curr_filter_att_uncertainty_.pitch;
               nav_msg_.pose.covariance[35] = curr_filter_att_uncertainty_.yaw*curr_filter_att_uncertainty_.yaw;
-            
+
               if (publish_filtered_imu_)
               {
-                filtered_imu_msg_.orientation_covariance[0] = curr_filter_att_uncertainty_.roll*curr_filter_att_uncertainty_.roll;
-                filtered_imu_msg_.orientation_covariance[4] = curr_filter_att_uncertainty_.pitch*curr_filter_att_uncertainty_.pitch;
-                filtered_imu_msg_.orientation_covariance[8] = curr_filter_att_uncertainty_.yaw*curr_filter_att_uncertainty_.yaw;
+                filtered_imu_msg_.orientation_covariance[0] =
+                    curr_filter_att_uncertainty_.roll*curr_filter_att_uncertainty_.roll;
+                filtered_imu_msg_.orientation_covariance[4] =
+                    curr_filter_att_uncertainty_.pitch*curr_filter_att_uncertainty_.pitch;
+                filtered_imu_msg_.orientation_covariance[8] =
+                    curr_filter_att_uncertainty_.yaw*curr_filter_att_uncertainty_.yaw;
               }
             }
             break;
@@ -3429,7 +3431,7 @@ namespace Microstrain
             {
               memcpy(&curr_filter_linear_accel_, field_data, sizeof(mip_filter_linear_acceleration));
 
-              //For little-endian targets, byteswap the data field
+              // For little-endian targets, byteswap the data field
               mip_filter_linear_acceleration_byteswap(&curr_filter_linear_accel_);
 
               // If we want gravity removed, use this as acceleration
@@ -3446,10 +3448,9 @@ namespace Microstrain
 
             case MIP_FILTER_DATA_COMPENSATED_ACCELERATION:
             {
-
               memcpy(&curr_filter_accel_comp_, field_data, sizeof(mip_filter_compensated_acceleration));
 
-              //For little-endian targets, byteswap the data field
+              // For little-endian targets, byteswap the data field
               mip_filter_compensated_acceleration_byteswap(&curr_filter_accel_comp_);
 
               // If we do not want to have gravity removed, use this as acceleration
@@ -3476,13 +3477,15 @@ namespace Microstrain
 
         if (publish_filtered_imu_)
         {
-          // TODO: Does it make sense to get the angular velocity bias and acceleration bias to populate these?
+          // Does it make sense to get the angular velocity bias and acceleration bias to populate these?
           // Since the sensor does not produce a covariance for linear acceleration, set it based
           // on our pulled in parameters.
-          std::copy( imu_linear_cov_.begin(), imu_linear_cov_.end(), filtered_imu_msg_.linear_acceleration_covariance.begin());
+          std::copy(imu_linear_cov_.begin(), imu_linear_cov_.end(),
+              filtered_imu_msg_.linear_acceleration_covariance.begin());
           // Since the sensor does not produce a covariance for angular velocity, set it based
           // on our pulled in parameters.
-          std::copy( imu_angular_cov_.begin(), imu_angular_cov_.end(), filtered_imu_msg_.angular_velocity_covariance.begin());
+          std::copy(imu_angular_cov_.begin(), imu_angular_cov_.end(),
+              filtered_imu_msg_.angular_velocity_covariance.begin());
 
           filtered_imu_pub_.publish(filtered_imu_msg_);
         }

--- a/src/microstrain_3dm.cpp
+++ b/src/microstrain_3dm.cpp
@@ -992,6 +992,10 @@ namespace Microstrain
     {
       max_rate = std::max(max_rate, imu_rate_);
     }
+    if (publish_filtered_imu_)
+    {
+      max_rate = std::max(max_rate, nav_rate_);
+    }
     if (publish_gps_)
     {
       max_rate = std::max(max_rate, gps_rate_);

--- a/src/microstrain_3dm.cpp
+++ b/src/microstrain_3dm.cpp
@@ -3344,10 +3344,10 @@ namespace Microstrain
               else
               {
                 // put into ENU - swap X/Y, invert Z
-                quat_msg.x = q[2];
-                quat_msg.y = q[1];
-                quat_msg.z = -1.0*q[3];
-                quat_msg.w = q[0];
+                quat_msg.x = q[1];
+                quat_msg.y = q[0];
+                quat_msg.z = -1.0*q[2];
+                quat_msg.w = q[3];
               }
 
               nav_msg_.pose.pose.orientation = quat_msg;
@@ -3719,10 +3719,10 @@ namespace Microstrain
               else
               {
                 // put into ENU - swap X/Y, invert Z
-                quat_msg.x = q[2];
-                quat_msg.y = q[1];
-                quat_msg.z = -1.0*q[3];
-                quat_msg.w = q[0];
+                quat_msg.x = q[1];
+                quat_msg.y = q[0];
+                quat_msg.z = -1.0*q[2];
+                quat_msg.w = q[3];
               }
 
               imu_msg_.orientation = quat_msg;

--- a/src/microstrain_3dm.cpp
+++ b/src/microstrain_3dm.cpp
@@ -155,6 +155,7 @@ namespace Microstrain
     private_nh.param("publish_bias", publish_bias_, true);
     private_nh.param("publish_filtered_imu", publish_filtered_imu_, false);
     private_nh.param("remove_imu_gravity", remove_imu_gravity_, false);
+    private_nh.param("frame_based_enu", frame_based_enu_, false);
 
     // Covariance parameters to set the sensor_msg/IMU covariance values
     std::vector<double> default_cov(9, 0.0);


### PR DESCRIPTION
This PR applies a patch to how the NED to ENU swap is done. As pointed out in issue #4 when applying the X & Y swap with Z inverted we get a problem of the orientation frame not matching the label of the actual device. This makes things difficult for a bit when setting up the device.

If the parameter `frame_based_enu` is set to true, the quaternion orientation will match what is printed on the device label. This makes it much easier for setting up your transforms and also fixes the issue of accelerations not pointing in the same direction of the quaternion.

The parameter `frame_based_enu` defaults to false so technically no user will see a change unless they specify this to be true. 