### PR TITLE
Minor fix: avoid buffer overflow in example code

### DIFF
--- a/MIPSDK/C/Examples/Linux/GX4-45/GX4_45_Test/GX4-45_Test.c
+++ b/MIPSDK/C/Examples/Linux/GX4-45/GX4_45_Test/GX4-45_Test.c
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
 {
  u32 com_port, baudrate;
  base_device_info_field device_info;
- u8  temp_string[20] = {0};
+ u8  temp_string[22] = {0};
  u32 bit_result;
  u8  enable = 1;
  u8  data_stream_format_descriptors[10];

--- a/MIPSDK/C/Examples/Linux/RQ1/RQ1_Test/RQ1_Test.c
+++ b/MIPSDK/C/Examples/Linux/RQ1/RQ1_Test/RQ1_Test.c
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
 {
  u32 com_port, baudrate;
  base_device_info_field device_info;
- u8  temp_string[20] = {0};
+ u8  temp_string[22] = {0};
  u32 bit_result;
  u8  enable = 1;
  u8  data_stream_format_descriptors[10];

--- a/MIPSDK/C/Examples/Windows/GX4-45/GX4-45_Test/GX4-45_Test.c
+++ b/MIPSDK/C/Examples/Windows/GX4-45/GX4-45_Test/GX4-45_Test.c
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
 {
  u32 com_port, baudrate;
  base_device_info_field device_info;
- u8  temp_string[20] = {0};
+ u8  temp_string[22] = {0};
  u32 bit_result;
  u8  enable = 1;
  u8  data_stream_format_descriptors[10];

--- a/MIPSDK/C/Examples/Windows/RQ1/RQ1_Test/RQ1_Test.c
+++ b/MIPSDK/C/Examples/Windows/RQ1/RQ1_Test/RQ1_Test.c
@@ -102,7 +102,7 @@ int main(int argc, char* argv[])
 {
  u32 com_port, baudrate;
  base_device_info_field device_info;
- u8  temp_string[20] = {0};
+ u8  temp_string[22] = {0};
  u32 bit_result;
  u8  enable = 1;
  u8  data_stream_format_descriptors[10];

--- a/src/GX4-45_Test.c
+++ b/src/GX4-45_Test.c
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
 {
  u32 com_port, baudrate;
  base_device_info_field device_info;
- u8  temp_string[20] = {0};
+ u8  temp_string[22] = {0};
  u32 bit_result;
  u8  enable = 1;
  u8  data_stream_format_descriptors[10];

--- a/src/GX4-45_Test.cpp
+++ b/src/GX4-45_Test.cpp
@@ -100,7 +100,7 @@ int main(int argc, char* argv[])
 {
  u32 com_port, baudrate;
  base_device_info_field device_info;
- u8  temp_string[20] = {0};
+ u8  temp_string[22] = {0};
  u32 bit_result;
  u8  enable = 1;
  u8  data_stream_format_descriptors[10];


### PR DESCRIPTION
As indicated by Frama-C, the string `System Initialization` (copied to `temp_string`) requires 22 bytes, including the null terminator, but the buffer was declared with only 20.

The change has not been ported to the test cases which do not print `System Initialization`.